### PR TITLE
restic_architecture variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 restic_install: false
 restic_version: 0.14.0
+restic_architecture: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
 restic_path: /usr/local/bin/restic
 restic_user: root
 restic_user_home: /root

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 restic_install: false
 restic_version: 0.14.0
-restic_architecture: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
 restic_path: /usr/local/bin/restic
 restic_user: root
 restic_user_home: /root
@@ -26,3 +25,8 @@ restic_ssh_private_key_path: "/root/.ssh/backup"
 
 restic_systemd_timer_on_calender: "*-*-* 03:00:00"
 restic_systemd_timer_randomized_delay_sec: 0
+
+restic_arch_map:
+  i386: '386'
+  x86_64: 'amd64'
+  aarch64: 'arm64'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,23 +13,23 @@
 
 - name: Download restic
   ansible.builtin.get_url:
-    url: "https://github.com/restic/restic/releases/download/v{{ restic_version }}/restic_{{ restic_version }}_linux_{{ ansible_architecture }}.bz2"
-    dest: "/tmp/restic_{{ restic_version }}_linux_amd64.bz2"
+    url: "https://github.com/restic/restic/releases/download/v{{ restic_version }}/restic_{{ restic_version }}_linux_{{ restic_architecture }}.bz2"
+    dest: "/tmp/restic_{{ restic_version }}_linux_{{ restic_architecture }}.bz2"
     mode: "0644"
 
 - name: Extract restic
-  ansible.builtin.command: "bzip2 -d /tmp/restic_{{ restic_version }}_linux_amd64.bz2"
+  ansible.builtin.command: "bzip2 -d /tmp/restic_{{ restic_version }}_linux_{{ restic_architecture }}.bz2"
   args:
-    creates: "/tmp/restic_{{ restic_version }}_linux_amd64"
+    creates: "/tmp/restic_{{ restic_version }}_linux_{{ restic_architecture }}"
 
 - name: Install restic
   ansible.builtin.copy:
     remote_src: true
-    src: "/tmp/restic_{{ restic_version }}_linux_amd64"
+    src: "/tmp/restic_{{ restic_version }}_linux_{{ restic_architecture }}"
     dest: "{{ restic_path }}"
     mode: "0755"
 
 - name: Remove downloaded file
   ansible.builtin.file:
-    path: "/tmp/restic_{{ restic_version }}_linux_amd64"
+    path: "/tmp/restic_{{ restic_version }}_linux_{{ restic_architecture }}"
     state: absent

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,23 +13,23 @@
 
 - name: Download restic
   ansible.builtin.get_url:
-    url: "https://github.com/restic/restic/releases/download/v{{ restic_version }}/restic_{{ restic_version }}_linux_{{ restic_architecture }}.bz2"
-    dest: "/tmp/restic_{{ restic_version }}_linux_{{ restic_architecture }}.bz2"
+    url: "https://github.com/restic/restic/releases/download/v{{ restic_version }}/restic_{{ restic_version }}_linux_{{ restic_arch_map[ansible_architecture] | default(ansible_architecture) }}.bz2"
+    dest: "/tmp/restic_{{ restic_version }}_linux_{{ restic_arch_map[ansible_architecture] | default(ansible_architecture) }}.bz2"
     mode: "0644"
 
 - name: Extract restic
-  ansible.builtin.command: "bzip2 -d /tmp/restic_{{ restic_version }}_linux_{{ restic_architecture }}.bz2"
+  ansible.builtin.command: "bzip2 -d /tmp/restic_{{ restic_version }}_linux_{{ restic_arch_map[ansible_architecture] | default(ansible_architecture) }}.bz2"
   args:
-    creates: "/tmp/restic_{{ restic_version }}_linux_{{ restic_architecture }}"
+    creates: "/tmp/restic_{{ restic_version }}_linux_{{ restic_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 
 - name: Install restic
   ansible.builtin.copy:
     remote_src: true
-    src: "/tmp/restic_{{ restic_version }}_linux_{{ restic_architecture }}"
+    src: "/tmp/restic_{{ restic_version }}_linux_{{ restic_arch_map[ansible_architecture] | default(ansible_architecture) }}"
     dest: "{{ restic_path }}"
     mode: "0755"
 
 - name: Remove downloaded file
   ansible.builtin.file:
-    path: "/tmp/restic_{{ restic_version }}_linux_{{ restic_architecture }}"
+    path: "/tmp/restic_{{ restic_version }}_linux_{{ restic_arch_map[ansible_architecture] | default(ansible_architecture) }}"
     state: absent


### PR DESCRIPTION
Thanks for for library! Was super-helpful setting up a basic backup job via Ansible 👍 

Just had an issue with the restic package download, as my environment returned `x86_64`, but the package download for restic is labelled `amd64`. So the download of the restic package was always failing.

I did a few changes to make it work, that I'd like to suggest to you:

- Instead of using the `ansible_architecture` fact directly, this is adding a `restic_architecture` default variable, which can be overwritten, if needed.
- Also adding a mapping from `x86_64` to `amd64` to that variable, so that the package download for `x86_64` architecture works

Let me know what you think!