### PR TITLE
Add pre-check for repository initialization in systemd service template

### DIFF
--- a/templates/restic-backup.service.j2
+++ b/templates/restic-backup.service.j2
@@ -19,6 +19,8 @@ Environment="AWS_ACCESS_KEY_ID={{ restic_aws_access_key_id}}"
 Environment="AWS_SECRET_ACCESS_KEY={{ restic_aws_secret_access_key}}"
 {% endif %}
 
+ExecStartPre=/bin/sh -c '{{ restic_path }} snapshots || {{ restic_path }} init'
+
 {% if restic_check %}
 ExecStartPre={{ restic_path }} check
 {% endif -%}


### PR DESCRIPTION
## Description

This pull request introduces a pre-check in the `restic-backup.service.j2` template to ensure that the Restic repository is initialized before running any backup operations. Specifically, an `ExecStartPre` command is added to verify the existence of snapshots in the repository. If the repository is not yet initialized, the command will automatically initialize it.

## Changes

- Added a pre-check in the systemd service template to verify and initialize the Restic repository if it is not already set up.
- The new command ensures that the `restic init` command is only run when necessary, preventing potential errors related to uninitialized repositories.

## Why this is needed

Without this change, if the Restic repository isn't initialized beforehand, the backup service may fail to start, causing interruptions in the backup process. This update makes the service more robust and capable of handling cases where the repository might not have been set up yet.

## Testing

- Tested by restarting the `restic-backup` service and verifying that it correctly initializes the repository if needed, without any manual intervention.
