### PR TITLE
Fix: change ansible.builtin.apt to ansible.builtin.package

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,7 +8,7 @@
     name: bzip2
 
 - name: Install pigz (to compress db dumps)
-  ansible.builtin.pakage:
+  ansible.builtin.package:
     name: pigz
 
 - name: Download restic


### PR DESCRIPTION
Currently installing prerequisites with `ansible.builtin.apt` module, but the role doesn't have any other platform specifc requirements, so switched it out with a  more generic module. 